### PR TITLE
Schedule Pickup Screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,8 @@ android {
         }
     }
     compileOptions {
+        // Flag to enable support for the new language APIs
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -89,4 +91,8 @@ dependencies {
 
     // material icons extended
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
+
+    // date-time picker
+    implementation "io.github.vanpra.compose-material-dialogs:datetime:$date_time_picker_version"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$desugar_jdk_libs_version"
 }

--- a/app/src/main/java/com/example/uberbookingexperience/MainActivity.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.uberbookingexperience.ui.screens.Screens
 import com.example.uberbookingexperience.ui.screens.dashboard.DashboardScreen
 import com.example.uberbookingexperience.ui.screens.paymentOptions.PaymentOptionsScreen
+import com.example.uberbookingexperience.ui.screens.schedulePickup.SchedulePickupScreen
 import com.example.uberbookingexperience.ui.screens.splash.SplashScreen
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
 import com.example.uberbookingexperience.ui.util.changeSystemBarsColor
@@ -71,6 +72,13 @@ class MainActivity : ComponentActivity() {
 
                         composable(Screens.PaymentOptionsScreen()) {
                             PaymentOptionsScreen { navController.navigateUp() }
+                        }
+
+                        composable(Screens.SchedulePickupScreen()) {
+                            SchedulePickupScreen(
+                                onNavigationIconClick = { navController.navigateUp() },
+                                onScheduleButtonClick = { _, _ -> }
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/common/UberButton.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/common/UberButton.kt
@@ -1,0 +1,45 @@
+package com.example.uberbookingexperience.ui.common
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import com.example.uberbookingexperience.ui.theme.spacing
+
+/**
+ * An Uber-styled button that helps its users initiate actions.
+ * @param modifier the [Modifier] to be applied to this button
+ * @param text the text to be displayed
+ * @param onClick called when this button is clicked
+ * */
+@Composable
+fun UberButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit
+) {
+    Button(
+        modifier = modifier
+            .padding(horizontal = MaterialTheme.spacing.small)
+            .padding(top = MaterialTheme.spacing.extraLarge)
+            .fillMaxWidth(),
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RectangleShape,
+        contentPadding = PaddingValues(vertical = MaterialTheme.spacing.medium)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.headlineMedium
+        )
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/common/UberDivider.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/common/UberDivider.kt
@@ -1,0 +1,16 @@
+package com.example.uberbookingexperience.ui.common
+
+import androidx.compose.material3.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.dp
+
+/**
+ * Uber Design divider.
+ * @param modifier the Modifier to be applied to this divider line
+ * */
+@Composable
+fun UberDivider(modifier: Modifier = Modifier) {
+    Divider(modifier = modifier.alpha(0.15f), thickness = 1.5.dp)
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/common/UberTopBar.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/common/UberTopBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.theme.spacing
 import com.example.uberbookingexperience.ui.util.UberIconSize
 
 /**
@@ -58,11 +59,11 @@ fun UberTopBar(
 private fun UberTopBarSample() {
     val goToPreviousScreen = {}
     UberTopBar(
-        modifier = Modifier.padding(horizontal = 8.dp),
+        modifier = Modifier.padding(horizontal = MaterialTheme.spacing.small),
         icon = Icons.Default.Close,
         iconOnClick = { goToPreviousScreen() },
         title = "Welcome to Uber",
-        titleOffsetFromIcon = 8.dp
+        titleOffsetFromIcon = MaterialTheme.spacing.small
     )
 }
 
@@ -75,7 +76,7 @@ private fun UberTopBarPreview() {
     UberBookingExperienceTheme {
         UberTopBar(
             title = "When do you want to be picked up?",
-            titleOffsetFromIcon = 8.dp
+            titleOffsetFromIcon = MaterialTheme.spacing.small
         ) {}
     }
 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/Screens.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/Screens.kt
@@ -3,6 +3,8 @@ package com.example.uberbookingexperience.ui.screens
 enum class Screens(private val route: String) {
     SplashScreen("splashScreen"),
     DashboardScreen("dashboardScreen"),
-    PaymentOptionsScreen("paymentOptionsScreen");
+    PaymentOptionsScreen("paymentOptionsScreen"),
+    SchedulePickupScreen("schedulePickupScreen");
+
     operator fun invoke() = route
 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/BusinessPaymentOptionScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/BusinessPaymentOptionScreen.kt
@@ -3,7 +3,6 @@ package com.example.uberbookingexperience.ui.screens.paymentOptions.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -15,8 +14,6 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -24,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -33,7 +29,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.uberbookingexperience.R
+import com.example.uberbookingexperience.ui.common.UberButton
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.theme.spacing
 import com.example.uberbookingexperience.ui.util.UberIconSize
 import com.example.uberbookingexperience.ui.util.rememberIsMobileDevice
 
@@ -45,16 +43,16 @@ fun BusinessPaymentOptionScreen() {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(MaterialTheme.spacing.medium),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Surface(
             modifier = requiredSizeModifier,
             color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.1f),
-            shape = RoundedCornerShape(8.dp)
+            shape = RoundedCornerShape(MaterialTheme.spacing.small)
         ) {
             Column(
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier.padding(MaterialTheme.spacing.medium)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -63,7 +61,7 @@ fun BusinessPaymentOptionScreen() {
                 ) {
                     Image(
                         modifier = Modifier
-                            .padding(start = 16.dp)
+                            .padding(start = MaterialTheme.spacing.medium)
                             .size(UberIconSize.LargeIcon)
                             .aspectRatio(1f),
                         painter = painterResource(id = R.drawable.ic_business_travel),
@@ -93,24 +91,11 @@ fun BusinessPaymentOptionScreen() {
         if (rememberIsMobileDevice()) {
             Spacer(modifier = Modifier.weight(1f))
         }
-        Button(
-            modifier = requiredSizeModifier
-                .padding(horizontal = 8.dp)
-                .padding(top = 32.dp)
-                .fillMaxWidth(),
-            onClick = {},
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.onSurface,
-                contentColor = MaterialTheme.colorScheme.surface
-            ),
-            shape = RectangleShape,
-            contentPadding = PaddingValues(vertical = 16.dp)
-        ) {
-            Text(
-                text = "Turn on",
-                style = MaterialTheme.typography.headlineMedium
-            )
-        }
+        UberButton(
+            modifier = requiredSizeModifier,
+            text = "Turn on",
+            onClick = {}
+        )
     }
 }
 
@@ -121,10 +106,10 @@ private fun BusinessBannerText(
     value: String
 ) {
     Row(
-        modifier = Modifier.padding(top = 16.dp)
+        modifier = Modifier.padding(top = MaterialTheme.spacing.medium)
     ) {
         Image(
-            modifier = Modifier.padding(end = 16.dp),
+            modifier = Modifier.padding(end = MaterialTheme.spacing.medium),
             imageVector = imageVector,
             contentDescription = null
         )
@@ -134,7 +119,7 @@ private fun BusinessBannerText(
                 fontWeight = FontWeight.Medium
             )
             Text(
-                modifier = Modifier.padding(top = 8.dp).fillMaxWidth(0.8f),
+                modifier = Modifier.padding(top = MaterialTheme.spacing.small).fillMaxWidth(0.8f),
                 text = value,
                 style = MaterialTheme.typography.bodyLarge
             )

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/DesktopPaymentOptionItem.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/DesktopPaymentOptionItem.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.example.uberbookingexperience.R
 import com.example.uberbookingexperience.ui.screens.paymentOptions.PaymentOption
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,8 +77,8 @@ fun DesktopPaymentOptionItem(paymentOption: PaymentOption) {
     ) {
         optionIcon()
         Text(
-            modifier = Modifier.fillMaxWidth().wrapContentSize().padding(horizontal = 8.dp)
-                .padding(top = 8.dp),
+            modifier = Modifier.fillMaxWidth().wrapContentSize().padding(horizontal = MaterialTheme.spacing.small)
+                .padding(top = MaterialTheme.spacing.small),
             text = paymentOption.name,
             style = MaterialTheme.typography.bodyMedium,
             maxLines = 2,
@@ -87,7 +88,7 @@ fun DesktopPaymentOptionItem(paymentOption: PaymentOption) {
         paymentOption.value?.let { nnValue ->
             Text(
                 modifier = Modifier.alpha(0.5f).fillMaxWidth().wrapContentSize()
-                    .padding(horizontal = 8.dp),
+                    .padding(horizontal = MaterialTheme.spacing.small),
                 text = nnValue,
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/DesktopPaymentOptionItem.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/DesktopPaymentOptionItem.kt
@@ -34,18 +34,21 @@ import com.example.uberbookingexperience.R
 import com.example.uberbookingexperience.ui.screens.paymentOptions.PaymentOption
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
 import com.example.uberbookingexperience.ui.theme.spacing
+import com.example.uberbookingexperience.ui.util.systemTween
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DesktopPaymentOptionItem(paymentOption: PaymentOption) {
     val containerColor by animateColorAsState(
         targetValue = if (paymentOption.selected) MaterialTheme.colorScheme.onSurface
-        else MaterialTheme.colorScheme.surface
+        else MaterialTheme.colorScheme.surface,
+        animationSpec = systemTween()
     )
 
     val contentColor by animateColorAsState(
         targetValue = if (paymentOption.selected) MaterialTheme.colorScheme.surface
-        else MaterialTheme.colorScheme.onSurface
+        else MaterialTheme.colorScheme.onSurface,
+        animationSpec = systemTween()
     )
 
     // Extracted it out since it didn't need to be recomposed when either container or content

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/MobilePaymentOptionItem.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/MobilePaymentOptionItem.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
 import com.example.uberbookingexperience.ui.screens.paymentOptions.PaymentOption
+import com.example.uberbookingexperience.ui.theme.spacing
 import com.example.uberbookingexperience.ui.util.UberIconSize
 import com.example.uberbookingexperience.ui.util.clickableWithRipple
 
@@ -36,7 +36,7 @@ fun MobilePaymentOptionItem(
     val optionIcon = remember(paymentOption.icon) {
         movableContentOf {
             Image(
-                modifier = Modifier.padding(vertical = 8.dp).size(UberIconSize.ListItem)
+                modifier = Modifier.padding(vertical = MaterialTheme.spacing.small).size(UberIconSize.ListItem)
                     .aspectRatio(1.5f).clip(shape = RoundedCornerShape(20)),
                 painter = painterResource(id = paymentOption.icon),
                 contentDescription = null,

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/PayeeType.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/PayeeType.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.uberbookingexperience.ui.theme.spacing
 
 @Composable
 fun PayeeType(
@@ -21,7 +22,7 @@ fun PayeeType(
     ) {
         item {
             UberSelectableChip(
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier.padding(start = MaterialTheme.spacing.small),
                 title = "Personal",
                 isSelected = selectedItemTitle == "Personal",
                 icon = Icons.Filled.Person,
@@ -32,7 +33,7 @@ fun PayeeType(
         }
         item {
             UberSelectableChip(
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier.padding(start = MaterialTheme.spacing.small),
                 title = "Business",
                 isSelected = selectedItemTitle == "Business",
                 icon = Icons.Filled.Work,

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/PaymentOptionsCategory.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/PaymentOptionsCategory.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.uberbookingexperience.ui.screens.paymentOptions.PaymentOption
+import com.example.uberbookingexperience.ui.theme.spacing
 import com.example.uberbookingexperience.ui.util.clickableWithRipple
 import com.example.uberbookingexperience.ui.util.rememberIsMobileDevice
 import com.google.accompanist.flowlayout.FlowRow
@@ -22,7 +23,8 @@ fun PaymentOptionsCategory(
     footer: String? = null,
     useSwitchForSelected: Boolean = false
 ) {
-    val paddingModifier = remember { Modifier.padding(horizontal = 16.dp) }
+    val commonPadding = MaterialTheme.spacing.medium
+    val paddingModifier = remember { Modifier.padding(horizontal = commonPadding) }
     Column(modifier = modifier) {
         Text(
             modifier = paddingModifier.padding(vertical = 12.dp),
@@ -48,7 +50,7 @@ fun PaymentOptionsCategory(
             }
         } else {
             FlowRow(
-                modifier = Modifier.padding(start = 16.dp)
+                modifier = Modifier.padding(start = MaterialTheme.spacing.medium)
             ) {
                 paymentOptions.forEach { paymentOption ->
                     DesktopPaymentOptionItem(paymentOption = paymentOption)
@@ -57,7 +59,7 @@ fun PaymentOptionsCategory(
         }
         footer?.let { nnFooter ->
             Text(
-                modifier = paddingModifier.padding(vertical = 16.dp).clickableWithRipple {},
+                modifier = paddingModifier.padding(vertical = MaterialTheme.spacing.medium).clickableWithRipple {},
                 text = nnFooter,
                 style = MaterialTheme.typography.headlineSmall.copy(
                     color = MaterialTheme.colorScheme.tertiary

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/UberSelectableChip.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/paymentOptions/components/UberSelectableChip.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.example.uberbookingexperience.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,7 +28,7 @@ fun UberSelectableChip(
     title: String,
     isSelected: Boolean,
     icon: ImageVector,
-    chipPadding: PaddingValues = PaddingValues(start = 8.dp),
+    chipPadding: PaddingValues = PaddingValues(start = MaterialTheme.spacing.small),
     contentPadding: PaddingValues = PaddingValues(10.dp),
     selectedBackgroundColor: Color = MaterialTheme.colorScheme.onSurface,
     elevation: Dp = 2.dp,

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
@@ -5,10 +5,10 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -30,11 +30,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.uberbookingexperience.R
+import com.example.uberbookingexperience.ui.common.UberButton
 import com.example.uberbookingexperience.ui.common.UberDivider
 import com.example.uberbookingexperience.ui.common.UberTopBar
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.theme.spacing
 import com.example.uberbookingexperience.ui.util.UberIconSize
 import com.example.uberbookingexperience.ui.util.clickableWithRipple
+import com.example.uberbookingexperience.ui.util.limitWidth
 import com.example.uberbookingexperience.ui.util.rememberIsMobileDevice
 
 @Composable
@@ -47,7 +50,7 @@ fun SchedulePickupScreen(
         UberTopBar(
             modifier = Modifier.align(Alignment.Start),
             title = "When do you want to be picked up?",
-            titleOffsetFromIcon = 8.dp,
+            titleOffsetFromIcon = MaterialTheme.spacing.small,
             iconOnClick = onNavigationIconClick
         )
         var currentDate by remember { mutableStateOf("Fri, 9 Sep") }
@@ -55,7 +58,8 @@ fun SchedulePickupScreen(
         val dateTimePicker: @Composable (Modifier) -> Unit = remember(currentDate, currentTime) {
             movableContentOf { modifier ->
                 Column(
-                    modifier = modifier.padding(horizontal = 32.dp).padding(top = 32.dp),
+                    modifier = modifier.padding(horizontal = MaterialTheme.spacing.extraLarge)
+                        .padding(top = MaterialTheme.spacing.extraLarge),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     SchedulePickupText(text = currentDate) {}
@@ -83,10 +87,10 @@ fun SchedulePickupScreen(
         val prebookingBenefitItems: @Composable (Modifier) -> Unit = remember(prebookingBenefits) {
             movableContentOf { modifier ->
                 Column(
-                    modifier = modifier.fillMaxWidth().padding(16.dp)
+                    modifier = modifier.fillMaxWidth().padding(MaterialTheme.spacing.medium)
                 ) {
                     Text(
-                        modifier = Modifier.padding(bottom = 16.dp),
+                        modifier = Modifier.padding(bottom = MaterialTheme.spacing.medium),
                         text = "Added flexibility if you book 2 hours ahead",
                         style = MaterialTheme.typography.headlineSmall
                     )
@@ -97,7 +101,8 @@ fun SchedulePickupScreen(
                         )
                     }
                     Text(
-                        modifier = Modifier.padding(24.dp).clickableWithRipple {},
+                        modifier = Modifier.padding(MaterialTheme.spacing.large)
+                            .clickableWithRipple {},
                         text = "See terms",
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.Medium,
@@ -106,7 +111,8 @@ fun SchedulePickupScreen(
                 }
             }
         }
-        Crossfade(targetState = rememberIsMobileDevice()) { isMobileDevice ->
+        val isMobile = rememberIsMobileDevice()
+        Crossfade(targetState = isMobile) { isMobileDevice ->
             if (isMobileDevice) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally
@@ -120,11 +126,20 @@ fun SchedulePickupScreen(
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    dateTimePicker(Modifier.widthIn(max = 400.dp))
-                    prebookingBenefitItems(Modifier.widthIn(max = 400.dp))
+                    dateTimePicker(Modifier.limitWidth())
+                    prebookingBenefitItems(Modifier.limitWidth())
                 }
             }
         }
+        if (isMobile) {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+        UberButton(
+            modifier = Modifier
+                .padding(MaterialTheme.spacing.medium)
+                .limitWidth(),
+            text = "Set pickup time"
+        ) {}
     }
 }
 
@@ -135,7 +150,8 @@ private fun SchedulePickupText(
     onClick: () -> Unit
 ) {
     Text(
-        modifier = modifier.clickableWithRipple(onClick = onClick).padding(16.dp).fillMaxWidth(),
+        modifier = modifier.clickableWithRipple(onClick = onClick)
+            .padding(MaterialTheme.spacing.medium).fillMaxWidth(),
         text = text,
         textAlign = TextAlign.Center
     )

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
@@ -150,6 +150,7 @@ fun SchedulePickupScreen(
 
     UberDateTimePicker(dialogState = datePickerDialogState) {
         datepicker(
+            initialDate = currentDate,
             colors = DatePickerDefaults.colors(
                 headerBackgroundColor = MaterialTheme.colorScheme.primary,
                 headerTextColor = MaterialTheme.colorScheme.onPrimary,
@@ -164,6 +165,7 @@ fun SchedulePickupScreen(
 
     UberDateTimePicker(dialogState = timePickerDialogState) {
         timepicker(
+            initialTime = currentTime,
             colors = TimePickerDefaults.colors(
                 activeBackgroundColor = MaterialTheme.colorScheme.primary,
                 inactiveBackgroundColor = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
@@ -1,0 +1,184 @@
+package com.example.uberbookingexperience.ui.screens.schedulePickup
+
+import androidx.annotation.DrawableRes
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.uberbookingexperience.R
+import com.example.uberbookingexperience.ui.common.UberDivider
+import com.example.uberbookingexperience.ui.common.UberTopBar
+import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.util.UberIconSize
+import com.example.uberbookingexperience.ui.util.clickableWithRipple
+import com.example.uberbookingexperience.ui.util.rememberIsMobileDevice
+
+@Composable
+fun SchedulePickupScreen(
+    onNavigationIconClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        UberTopBar(
+            modifier = Modifier.align(Alignment.Start),
+            title = "When do you want to be picked up?",
+            titleOffsetFromIcon = 8.dp,
+            iconOnClick = onNavigationIconClick
+        )
+        var currentDate by remember { mutableStateOf("Fri, 9 Sep") }
+        var currentTime by remember { mutableStateOf("18:00") }
+        val dateTimePicker: @Composable (Modifier) -> Unit = remember(currentDate, currentTime) {
+            movableContentOf { modifier ->
+                Column(
+                    modifier = modifier.padding(horizontal = 32.dp).padding(top = 32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    SchedulePickupText(text = currentDate) {}
+                    UberDivider()
+                    SchedulePickupText(text = currentTime) {}
+                }
+            }
+        }
+        val prebookingBenefits = remember {
+            mutableStateListOf(
+                PrebookingBenefitItem(
+                    icon = R.drawable.ic_calendar,
+                    text = "Choose your exact pick-up time up to 30 days in advance"
+                ),
+                PrebookingBenefitItem(
+                    icon = R.drawable.ic_hourglass,
+                    text = "Extra wait time included to meet your trip"
+                ),
+                PrebookingBenefitItem(
+                    icon = R.drawable.ic_credit_card,
+                    text = "Cancel at no charge up to 60 minutes in advance"
+                )
+            )
+        }
+        val prebookingBenefitItems: @Composable (Modifier) -> Unit = remember(prebookingBenefits) {
+            movableContentOf { modifier ->
+                Column(
+                    modifier = modifier.fillMaxWidth().padding(16.dp)
+                ) {
+                    Text(
+                        modifier = Modifier.padding(bottom = 16.dp),
+                        text = "Added flexibility if you book 2 hours ahead",
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                    prebookingBenefits.forEachIndexed { index, prebookingBenefitItem ->
+                        PrebookingBenefitsListItem(
+                            prebookingBenefitItem = prebookingBenefitItem,
+                            showDivider = index != prebookingBenefits.lastIndex
+                        )
+                    }
+                    Text(
+                        modifier = Modifier.padding(24.dp).clickableWithRipple {},
+                        text = "See terms",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        textDecoration = TextDecoration.Underline
+                    )
+                }
+            }
+        }
+        Crossfade(targetState = rememberIsMobileDevice()) { isMobileDevice ->
+            if (isMobileDevice) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    dateTimePicker(Modifier)
+                    prebookingBenefitItems(Modifier)
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    dateTimePicker(Modifier.widthIn(max = 400.dp))
+                    prebookingBenefitItems(Modifier.widthIn(max = 400.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SchedulePickupText(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit
+) {
+    Text(
+        modifier = modifier.clickableWithRipple(onClick = onClick).padding(16.dp).fillMaxWidth(),
+        text = text,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Immutable
+private data class PrebookingBenefitItem(
+    @DrawableRes val icon: Int,
+    val text: String
+)
+
+@Composable
+private fun PrebookingBenefitsListItem(
+    prebookingBenefitItem: PrebookingBenefitItem,
+    showDivider: Boolean
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            modifier = Modifier.padding(12.dp).size(UberIconSize.NormalIcon),
+            painter = painterResource(id = prebookingBenefitItem.icon),
+            contentDescription = null
+        )
+        Text(
+            text = prebookingBenefitItem.text,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Light,
+            letterSpacing = 0.5.sp
+        )
+    }
+    if (showDivider) {
+        UberDivider(Modifier.padding(start = 48.dp))
+    }
+}
+
+@Preview(showSystemUi = true, device = "spec:width=411dp,height=891dp")
+@Preview(showSystemUi = true, device = "spec:width=673.5dp,height=841dp,dpi=480")
+@Preview(showSystemUi = true, device = "spec:width=1280dp,height=800dp,dpi=480")
+@Preview(showSystemUi = true, device = "spec:width=1920dp,height=1080dp,dpi=480")
+@Composable
+private fun SchedulePickupScreenPreview() {
+    UberBookingExperienceTheme {
+        SchedulePickupScreen {}
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/SchedulePickupScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,7 +34,9 @@ import com.example.uberbookingexperience.ui.util.limitWidth
 import com.example.uberbookingexperience.ui.util.rememberIsMobileDevice
 import com.example.uberbookingexperience.ui.util.uberFormattedDate
 import com.example.uberbookingexperience.ui.util.uberFormattedTime
+import com.vanpra.composematerialdialogs.datetime.date.DatePickerDefaults
 import com.vanpra.composematerialdialogs.datetime.date.datepicker
+import com.vanpra.composematerialdialogs.datetime.time.TimePickerDefaults
 import com.vanpra.composematerialdialogs.datetime.time.timepicker
 import com.vanpra.composematerialdialogs.rememberMaterialDialogState
 import java.time.LocalDate
@@ -56,6 +59,7 @@ fun SchedulePickupScreen(
     var currentTime by rememberSaveable { mutableStateOf(LocalTime.now()) }
 
     Column(
+        modifier = Modifier.systemBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         UberTopBar(
@@ -144,9 +148,35 @@ fun SchedulePickupScreen(
         )
     }
 
-    UberDateTimePicker(dialogState = datePickerDialogState) { datepicker { currentDate = it } }
+    UberDateTimePicker(dialogState = datePickerDialogState) {
+        datepicker(
+            colors = DatePickerDefaults.colors(
+                headerBackgroundColor = MaterialTheme.colorScheme.primary,
+                headerTextColor = MaterialTheme.colorScheme.onPrimary,
+                calendarHeaderTextColor = MaterialTheme.colorScheme.primary,
+                dateActiveBackgroundColor = MaterialTheme.colorScheme.primary,
+                dateInactiveBackgroundColor = MaterialTheme.colorScheme.onPrimary,
+                dateActiveTextColor = MaterialTheme.colorScheme.onPrimary,
+                dateInactiveTextColor = MaterialTheme.colorScheme.primary
+            )
+        ) { currentDate = it }
+    }
 
-    UberDateTimePicker(dialogState = timePickerDialogState) { timepicker { currentTime = it } }
+    UberDateTimePicker(dialogState = timePickerDialogState) {
+        timepicker(
+            colors = TimePickerDefaults.colors(
+                activeBackgroundColor = MaterialTheme.colorScheme.primary,
+                inactiveBackgroundColor = MaterialTheme.colorScheme.onPrimary,
+                activeTextColor = MaterialTheme.colorScheme.onPrimary,
+                inactiveTextColor = MaterialTheme.colorScheme.primary,
+                inactivePeriodBackground = MaterialTheme.colorScheme.onPrimary,
+                selectorColor = MaterialTheme.colorScheme.primary,
+                selectorTextColor = MaterialTheme.colorScheme.onPrimary,
+                headerTextColor = MaterialTheme.colorScheme.primary,
+                borderColor = MaterialTheme.colorScheme.onPrimary
+            )
+        ) { currentTime = it }
+    }
 }
 
 @Preview(showSystemUi = true, device = "spec:width=411dp,height=891dp")

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/PrebookingBenefitsList.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/PrebookingBenefitsList.kt
@@ -1,0 +1,89 @@
+package com.example.uberbookingexperience.ui.screens.schedulePickup.components
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.uberbookingexperience.ui.common.UberDivider
+import com.example.uberbookingexperience.ui.theme.spacing
+import com.example.uberbookingexperience.ui.util.UberIconSize
+import com.example.uberbookingexperience.ui.util.clickableWithRipple
+
+@Immutable
+data class PrebookingBenefitItem(
+    @DrawableRes val icon: Int,
+    val text: String
+)
+
+@Composable
+fun PrebookingBenefitsList(
+    modifier: Modifier = Modifier,
+    prebookingBenefits: SnapshotStateList<PrebookingBenefitItem>
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(MaterialTheme.spacing.medium)
+    ) {
+        Text(
+            modifier = Modifier.padding(bottom = MaterialTheme.spacing.medium),
+            text = "Added flexibility if you book 2 hours ahead",
+            style = MaterialTheme.typography.headlineSmall
+        )
+        prebookingBenefits.forEachIndexed { index, prebookingBenefitItem ->
+            PrebookingBenefitsListItem(
+                prebookingBenefitItem = prebookingBenefitItem,
+                showDivider = index != prebookingBenefits.lastIndex
+            )
+        }
+        Text(
+            modifier = Modifier
+                .padding(MaterialTheme.spacing.large)
+                .clickableWithRipple {},
+            text = "See terms",
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            textDecoration = TextDecoration.Underline
+        )
+    }
+}
+
+@Composable
+private fun PrebookingBenefitsListItem(
+    prebookingBenefitItem: PrebookingBenefitItem,
+    showDivider: Boolean
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            modifier = Modifier.padding(12.dp).size(UberIconSize.NormalIcon),
+            painter = painterResource(id = prebookingBenefitItem.icon),
+            contentDescription = null
+        )
+        Text(
+            text = prebookingBenefitItem.text,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Light,
+            letterSpacing = 0.5.sp
+        )
+    }
+    if (showDivider) {
+        UberDivider(Modifier.padding(start = 48.dp))
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/SchedulePickupText.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/SchedulePickupText.kt
@@ -1,0 +1,25 @@
+package com.example.uberbookingexperience.ui.screens.schedulePickup.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.example.uberbookingexperience.ui.theme.spacing
+import com.example.uberbookingexperience.ui.util.clickableWithRipple
+
+@Composable
+fun SchedulePickupText(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit
+) {
+    Text(
+        modifier = modifier.clickableWithRipple(onClick = onClick)
+            .padding(MaterialTheme.spacing.medium).fillMaxWidth(),
+        text = text,
+        textAlign = TextAlign.Center
+    )
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/UberDateTimePicker.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/UberDateTimePicker.kt
@@ -1,5 +1,6 @@
 package com.example.uberbookingexperience.ui.screens.schedulePickup.components
 
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.DialogProperties
@@ -15,8 +16,18 @@ fun UberDateTimePicker(
     MaterialDialog(
         dialogState = dialogState,
         buttons = {
-            positiveButton("Ok")
-            negativeButton("Cancel")
+            positiveButton(
+                text = "Ok",
+                textStyle = LocalTextStyle.current.copy(
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            )
+            negativeButton(
+                text = "Cancel",
+                textStyle = LocalTextStyle.current.copy(
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+            )
         },
         properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
         onCloseRequest = { it.hide() },

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/UberDateTimePicker.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/schedulePickup/components/UberDateTimePicker.kt
@@ -1,0 +1,26 @@
+package com.example.uberbookingexperience.ui.screens.schedulePickup.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.DialogProperties
+import com.vanpra.composematerialdialogs.MaterialDialog
+import com.vanpra.composematerialdialogs.MaterialDialogScope
+import com.vanpra.composematerialdialogs.MaterialDialogState
+
+@Composable
+fun UberDateTimePicker(
+    dialogState: MaterialDialogState,
+    content: @Composable MaterialDialogScope.() -> Unit
+) {
+    MaterialDialog(
+        dialogState = dialogState,
+        buttons = {
+            positiveButton("Ok")
+            negativeButton("Cancel")
+        },
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
+        onCloseRequest = { it.hide() },
+        backgroundColor = MaterialTheme.colorScheme.surface,
+        content = content
+    )
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/theme/Spacing.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/theme/Spacing.kt
@@ -1,0 +1,58 @@
+package com.example.uberbookingexperience.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+class Spacing internal constructor(
+    val extraSmall: Dp = 4.dp,
+    val small: Dp = 8.dp,
+    val medium: Dp = 16.dp,
+    val large: Dp = 24.dp,
+    val extraLarge: Dp = 32.dp
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || other !is Spacing) return false
+
+        if (extraSmall != other.extraSmall) return false
+        if (small != other.small) return false
+        if (medium != other.medium) return false
+        if (large != other.large) return false
+        if (extraLarge != other.extraLarge) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = extraSmall.hashCode()
+        result = 31 * result + small.hashCode()
+        result = 31 * result + medium.hashCode()
+        result = 31 * result + large.hashCode()
+        result = 31 * result + extraLarge.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Spacing(extraSmall=$extraSmall, small=$small, medium=$medium, large=$large," +
+            "extraLarge=$extraLarge)"
+    }
+}
+
+/**
+ * CompositionLocal used to specify the default [Spacing] for composables.
+ * */
+val LocalSpacing = staticCompositionLocalOf { Spacing() }
+
+/**
+ * Retrieves the current [Spacing] at the call site's position in the hierarchy.
+ */
+val MaterialTheme.spacing
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalSpacing.current

--- a/app/src/main/java/com/example/uberbookingexperience/ui/util/AnimationUtil.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/util/AnimationUtil.kt
@@ -49,7 +49,7 @@ fun <T> systemTween(
  * A util function for easily changing systemBars colors.
  * */
 fun Activity.changeSystemBarsColor(
-    color: Color = Color.Transparent,
+    color: Color = Color.Transparent
 ) {
     if (window.statusBarColor != color.toArgb()) {
         window.statusBarColor = color.toArgb()
@@ -65,7 +65,7 @@ fun Activity.changeSystemBarsColor(
  * */
 fun SystemUiController.changeSystemBarsColor(
     color: Color = Color.Transparent,
-    darkIcons: Boolean = true,
+    darkIcons: Boolean = true
 ) {
     setSystemBarsColor(
         color = color,
@@ -86,6 +86,8 @@ private fun getAnimationDurationScale(): Float {
 
 private fun Activity.getAnimationDurationScale(): Float {
     return Settings.Global.getFloat(
-        contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f
+        contentResolver,
+        Settings.Global.ANIMATOR_DURATION_SCALE,
+        1.0f
     )
 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/util/ComposeUtil.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/util/ComposeUtil.kt
@@ -4,12 +4,16 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 @SuppressLint("ComposableModifierFactory")
 @Composable
@@ -22,6 +26,12 @@ fun Modifier.clickableWithRipple(
     indication = indication,
     onClick = onClick
 )
+
+/**
+ * Constrain the width of the content to be between mindp and maxdp as permitted by the incoming
+ * measurement [Constraints].
+ * */
+fun Modifier.limitWidth(min: Dp = 200.dp, max: Dp = 400.dp) = widthIn(min = min, max = max)
 
 @Composable
 fun rememberIsMobileDevice(): Boolean {

--- a/app/src/main/java/com/example/uberbookingexperience/ui/util/Util.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/util/Util.kt
@@ -1,6 +1,9 @@
 package com.example.uberbookingexperience.ui.util // ktlint-disable filename
 
 import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.Locale
 
 object UberIconSize {
     val Navigation = 36.dp
@@ -8,4 +11,19 @@ object UberIconSize {
     val TrailingIconSize = 16.dp
     val LargeIcon = 64.dp
     val NormalIcon = 24.dp
+}
+
+fun LocalDate.uberFormattedDate() =
+    "${dayOfWeek.name.substring(0, 3)}, $dayOfMonth ${month.name.substring(0, 3)}".toCamelCase()
+
+fun LocalTime.uberFormattedTime() = "$hour:${if (minute < 10) "0$minute" else "$minute"}"
+private fun String.toCamelCase(delimiter: String = " "): String {
+    val wordList = this.split(delimiter).map { word ->
+        word
+            .lowercase()
+            .replaceFirstChar {
+                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+            }
+    }
+    return wordList.joinToString(separator = delimiter)
 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/util/Util.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/util/Util.kt
@@ -7,4 +7,5 @@ object UberIconSize {
     val ListItem = 36.dp
     val TrailingIconSize = 16.dp
     val LargeIcon = 64.dp
+    val NormalIcon = 24.dp
 }

--- a/app/src/main/res/drawable/ic_calendar.xml
+++ b/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/black"
+        android:pathData="M23 8V4h-3V1h-3v3H7V1H4v3H1v4h22zm0 15H1V10h22v13zM8 14H5v3h3v-3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_credit_card.xml
+++ b/app/src/main/res/drawable/ic_credit_card.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/black"
+        android:pathData="M1 4h22v4H1V4zm0 7h22v9H1v-9z" />
+</vector>

--- a/app/src/main/res/drawable/ic_hourglass.xml
+++ b/app/src/main/res/drawable/ic_hourglass.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/black"
+        android:pathData="M19 5.5V4h1V1H4v3h1v1.5c0 2.95 1.83 5.47 4.41 6.5C6.83 13.03 5 15.55 5 18.5V20H4v3h16v-3h-1v-1.5c0-2.95-1.83-5.47-4.41-6.5C17.17 10.97 19 8.45 19 5.5zM16 4v1.5c0 0.53-0.11 1.04-0.3 1.5H8.3C8.11 6.54 8 6.03 8 5.5V4h8zm0 14.5V20H8v-1.5c0-2.21 1.79-4 4-4s4 1.79 4 4z" />
+</vector>

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ buildscript {
         ksp_version = "1.7.0-1.0.6"
         splash_screen_version = "1.0.0"
         nav_version = "2.5.2"
+        date_time_picker_version = "0.8.1-rc"
+        desugar_jdk_libs_version = "1.1.5"
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {


### PR DESCRIPTION
This PR deals with the creation of the `Schedule Pickup` Screen. The screen responds to configuration changes by moving the `DateTimePicker` section and the `PrebookingBenefitsList` section around to better utilize the available screen real estate.

Demo:

<img src="https://user-images.githubusercontent.com/89389061/190913229-f5900fa5-faf8-4d58-8c46-7dd046fc6915.gif" width="500" />
