### PR TITLE
Finalising Driver Screen (with ProgressBar animation)

### DIFF
--- a/app/src/main/java/com/example/uberbookingexperience/ui/common/UberBottomSheetListItem.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/common/UberBottomSheetListItem.kt
@@ -1,6 +1,8 @@
-package com.example.uberbookingexperience.ui.screens.finalisingDriver.components
+package com.example.uberbookingexperience.ui.common
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DividerDefaults
@@ -16,24 +18,29 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
-import com.example.uberbookingexperience.ui.common.UberDivider
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.uberbookingexperience.ui.theme.spacing
 import com.example.uberbookingexperience.ui.util.UberIconSize
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FinalisingDriverScreenListItem(
+fun UberBottomSheetListItem(
     icon: ImageVector,
+    iconSize: Dp = UberIconSize.NormalIcon,
     iconTint: Color? = null,
     title: String? = null,
     subtitle: String? = null,
     actionTitle: String? = null,
-    actionColor: Color = MaterialTheme.colorScheme.secondary
+    actionColor: Color = MaterialTheme.colorScheme.secondary,
+    useFullSizeDivider: Boolean = false,
+    dividerPadding: PaddingValues = PaddingValues()
 ) {
     Column {
         ListItem(
             leadingContent = {
                 Icon(
-                    modifier = Modifier.size(UberIconSize.NormalIcon),
+                    modifier = Modifier.size(iconSize),
                     imageVector = icon,
                     contentDescription = null,
                     tint = iconTint ?: LocalContentColor.current
@@ -75,7 +82,16 @@ fun FinalisingDriverScreenListItem(
             }
         )
         UberDivider(
-            thickness = DividerDefaults.Thickness
+            thickness = DividerDefaults.Thickness,
+            modifier = Modifier
+                .padding(
+                    start = if (useFullSizeDivider) {
+                        0.dp
+                    } else {
+                        iconSize + MaterialTheme.spacing.extraLarge
+                    }
+                )
+                .padding(dividerPadding)
         )
     }
 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/common/UberDivider.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/common/UberDivider.kt
@@ -1,9 +1,16 @@
 package com.example.uberbookingexperience.ui.common
 
+import androidx.annotation.FloatRange
 import androidx.compose.material3.Divider
+import androidx.compose.material3.DividerDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
@@ -11,6 +18,18 @@ import androidx.compose.ui.unit.dp
  * @param modifier the Modifier to be applied to this divider line
  * */
 @Composable
-fun UberDivider(modifier: Modifier = Modifier) {
-    Divider(modifier = modifier.alpha(0.15f), thickness = 1.5.dp)
+fun UberDivider(
+    modifier: Modifier = Modifier,
+    thickness: Dp = 1.5.dp,
+    @FloatRange(from = 0.0, to = 1.0) alpha: Float = 0.15f,
+    color: Color = DividerDefaults.color,
+    shape: Shape = RectangleShape
+) {
+    Divider(
+        modifier = modifier
+            .alpha(alpha)
+            .clip(shape),
+        thickness = thickness,
+        color = color
+    )
 }

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/FinalisingDriverScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/FinalisingDriverScreen.kt
@@ -1,0 +1,122 @@
+package com.example.uberbookingexperience.ui.screens.finalisingDriver
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.outlined.Error
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.uberbookingexperience.R
+import com.example.uberbookingexperience.ui.common.UberDivider
+import com.example.uberbookingexperience.ui.screens.finalisingDriver.components.FinalisingDriverScreenListItem
+import com.example.uberbookingexperience.ui.screens.finalisingDriver.components.HighlightItem
+import com.example.uberbookingexperience.ui.screens.finalisingDriver.components.ProgressBarAnimation
+import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.theme.spacing
+import com.example.uberbookingexperience.ui.util.DevicePreviews
+import com.example.uberbookingexperience.ui.util.rememberIsMobileDevice
+
+@Composable
+fun FinalisingDriverScreen(
+    onCancelButtonClick: () -> Unit = {}
+) {
+    Surface(
+        shadowElevation = 8.dp,
+        modifier = Modifier.wrapContentSize()
+    ) {
+        Column(
+            modifier = Modifier.then(
+                if (rememberIsMobileDevice()) {
+                    Modifier.fillMaxWidth()
+                } else {
+                    Modifier.width(300.dp)
+                }
+            ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            UberDivider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentWidth()
+                    .width(56.dp)
+                    .padding(top = MaterialTheme.spacing.small),
+                thickness = 4.dp,
+                shape = CircleShape,
+                alpha = 0.1f
+            )
+            Text(
+                modifier = Modifier
+                    .padding(MaterialTheme.spacing.medium)
+                    .align(Alignment.Start),
+                text = "Ride requested, finalising driver details",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Medium
+            )
+            UberDivider(alpha = 0.1f)
+            ProgressBarAnimation(
+                modifier = Modifier.padding(MaterialTheme.spacing.small)
+            )
+            HighlightItem(
+                modifier = Modifier.padding(MaterialTheme.spacing.large),
+                icon = R.drawable.ic_map_location,
+                title = "Dropoff by 17:26"
+            )
+            UberDivider()
+            FinalisingDriverScreenListItem(
+                icon = Icons.Filled.LocationOn,
+                title = "Dev Arc Commercial Complex",
+                subtitle = null,
+                actionTitle = "Add or Change"
+            )
+            FinalisingDriverScreenListItem(
+                icon = Icons.Outlined.Person,
+                title = "$7.58",
+                subtitle = "Personal \u00B7 Payment",
+                actionTitle = "Switch"
+            )
+            FinalisingDriverScreenListItem(
+                icon = Icons.Outlined.Error,
+                iconTint = MaterialTheme.colorScheme.error,
+                title = null,
+                subtitle = "We can't reach our network, so the trip total might be outdated",
+                actionTitle = null
+            )
+            TextButton(
+                modifier = Modifier.padding(horizontal = MaterialTheme.spacing.small),
+                onClick = onCancelButtonClick,
+                shape = RoundedCornerShape(10)
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Cancel",
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+private fun FinalisingDriverScreenPreview() {
+    UberBookingExperienceTheme {
+        FinalisingDriverScreen()
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/FinalisingDriverScreen.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/FinalisingDriverScreen.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.uberbookingexperience.R
+import com.example.uberbookingexperience.ui.common.UberBottomSheetListItem
 import com.example.uberbookingexperience.ui.common.UberDivider
-import com.example.uberbookingexperience.ui.screens.finalisingDriver.components.FinalisingDriverScreenListItem
 import com.example.uberbookingexperience.ui.screens.finalisingDriver.components.HighlightItem
 import com.example.uberbookingexperience.ui.screens.finalisingDriver.components.ProgressBarAnimation
 import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
@@ -78,19 +78,19 @@ fun FinalisingDriverScreen(
                 title = "Dropoff by 17:26"
             )
             UberDivider()
-            FinalisingDriverScreenListItem(
+            UberBottomSheetListItem(
                 icon = Icons.Filled.LocationOn,
                 title = "Dev Arc Commercial Complex",
                 subtitle = null,
                 actionTitle = "Add or Change"
             )
-            FinalisingDriverScreenListItem(
+            UberBottomSheetListItem(
                 icon = Icons.Outlined.Person,
                 title = "$7.58",
                 subtitle = "Personal \u00B7 Payment",
                 actionTitle = "Switch"
             )
-            FinalisingDriverScreenListItem(
+            UberBottomSheetListItem(
                 icon = Icons.Outlined.Error,
                 iconTint = MaterialTheme.colorScheme.error,
                 title = null,

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/components/FinalisingDriverScreenListItem.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/components/FinalisingDriverScreenListItem.kt
@@ -1,0 +1,81 @@
+package com.example.uberbookingexperience.ui.screens.finalisingDriver.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import com.example.uberbookingexperience.ui.common.UberDivider
+import com.example.uberbookingexperience.ui.util.UberIconSize
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FinalisingDriverScreenListItem(
+    icon: ImageVector,
+    iconTint: Color? = null,
+    title: String? = null,
+    subtitle: String? = null,
+    actionTitle: String? = null,
+    actionColor: Color = MaterialTheme.colorScheme.secondary
+) {
+    Column {
+        ListItem(
+            leadingContent = {
+                Icon(
+                    modifier = Modifier.size(UberIconSize.NormalIcon),
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint ?: LocalContentColor.current
+                )
+            },
+            headlineText = {
+                title?.let { nnTitle ->
+                    Text(
+                        text = nnTitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            },
+            supportingText = subtitle?.let { nnSubtitle ->
+                {
+                    Text(
+                        text = nnSubtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(
+                            alpha = 0.75f
+                        )
+                    )
+                }
+            },
+            trailingContent = actionTitle?.let { nnActionTitle ->
+                {
+                    TextButton(
+                        onClick = {},
+                        shape = RoundedCornerShape(10)
+                    ) {
+                        Text(
+                            text = nnActionTitle,
+                            color = actionColor,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+            }
+        )
+        UberDivider(
+            thickness = DividerDefaults.Thickness
+        )
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/components/HighlightItem.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/components/HighlightItem.kt
@@ -1,0 +1,44 @@
+package com.example.uberbookingexperience.ui.screens.finalisingDriver.components
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.uberbookingexperience.ui.theme.spacing
+
+@Composable
+fun HighlightItem(
+    modifier: Modifier = Modifier,
+    @DrawableRes icon: Int,
+    title: String
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            modifier = Modifier
+                .size(128.dp)
+                .clip(CircleShape),
+            painter = painterResource(id = icon),
+            contentDescription = null
+        )
+        Text(
+            modifier = Modifier.padding(vertical = MaterialTheme.spacing.medium),
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/components/ProgressBarAnimation.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/screens/finalisingDriver/components/ProgressBarAnimation.kt
@@ -1,0 +1,152 @@
+package com.example.uberbookingexperience.ui.screens.finalisingDriver.components
+
+import androidx.annotation.IntRange
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.uberbookingexperience.ui.theme.UberBookingExperienceTheme
+import com.example.uberbookingexperience.ui.theme.spacing
+import com.example.uberbookingexperience.ui.util.systemTween
+import kotlinx.coroutines.delay
+
+private const val ProgressStateChangeDelay: Long = 2000
+private const val ProgressAnimationDuration: Int = 1000
+private const val StateSwitchDuration: Int = 0
+
+private enum class ProgressAnimationState {
+    Loading, Loaded, Uninitialised
+}
+
+@Composable
+fun ProgressBarAnimation(
+    modifier: Modifier = Modifier,
+    @IntRange(from = 1, to = 6)
+    parts: Int = 4,
+    inactiveColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f),
+    progressColor: Color = MaterialTheme.colorScheme.secondary,
+    animationDurationMillis: Int = ProgressAnimationDuration,
+    spaceBetweenParts: Dp = MaterialTheme.spacing.extraSmall,
+    trackHeight: Dp = 4.dp,
+    onAnimationFinished: () -> Unit = {}
+) {
+    var selectedPart by rememberSaveable { mutableStateOf(1) }
+
+    LaunchedEffect(Unit) {
+        repeat(parts) { partIndex ->
+            selectedPart = partIndex + 1
+            delay(ProgressStateChangeDelay)
+            if (partIndex == parts) {
+                onAnimationFinished()
+            }
+        }
+    }
+
+    Row(modifier = modifier) {
+        repeat(parts) { partIndex ->
+            ProgressAnimation(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(spaceBetweenParts),
+                animationState = when {
+                    selectedPart == partIndex + 1 -> ProgressAnimationState.Loading
+                    selectedPart > partIndex + 1 -> ProgressAnimationState.Loaded
+                    else -> ProgressAnimationState.Uninitialised
+                },
+                trackColor = inactiveColor,
+                progressColor = progressColor,
+                animationDurationMillis = animationDurationMillis,
+                trackHeight = trackHeight
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProgressAnimation(
+    modifier: Modifier = Modifier,
+    animationState: ProgressAnimationState,
+    trackColor: Color,
+    progressColor: Color,
+    animationDurationMillis: Int,
+    trackHeight: Dp
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+
+    val animatedColor by infiniteTransition.animateColor(
+        initialValue = progressColor,
+        targetValue = Color.Transparent,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = animationDurationMillis
+                progressColor at 0
+                progressColor at animationDurationMillis.times(0.75f).toInt()
+                Color.Transparent at animationDurationMillis.times(0.9f).toInt()
+            }
+        )
+    )
+
+    val animatedProgress by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = animationDurationMillis
+                0f at 0
+                1f at animationDurationMillis.times(0.75f).toInt()
+                1f at animationDurationMillis
+            }
+        )
+    )
+
+    val conditionalColor by animateColorAsState(
+        targetValue = when (animationState) {
+            ProgressAnimationState.Uninitialised -> Color.Transparent
+            ProgressAnimationState.Loading -> animatedColor
+            ProgressAnimationState.Loaded -> progressColor
+        },
+        animationSpec = systemTween(durationMillis = StateSwitchDuration)
+    )
+    val conditionalProgress by animateFloatAsState(
+        targetValue = when (animationState) {
+            ProgressAnimationState.Uninitialised -> 0f
+            ProgressAnimationState.Loading -> animatedProgress
+            ProgressAnimationState.Loaded -> 1f
+        },
+        animationSpec = systemTween(durationMillis = StateSwitchDuration)
+    )
+
+    LinearProgressIndicator(
+        modifier = modifier.height(trackHeight),
+        progress = conditionalProgress,
+        color = conditionalColor,
+        trackColor = trackColor
+    )
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun ProgressBarAnimationPreview() {
+    UberBookingExperienceTheme {
+        ProgressBarAnimation()
+    }
+}

--- a/app/src/main/java/com/example/uberbookingexperience/ui/util/DevicePreviews.kt
+++ b/app/src/main/java/com/example/uberbookingexperience/ui/util/DevicePreviews.kt
@@ -1,0 +1,13 @@
+package com.example.uberbookingexperience.ui.util
+
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Multipreview annotation that represents various device sizes. Add this annotation to a composable
+ * to render various devices.
+ */
+@Preview(showSystemUi = true, device = "spec:width=411dp,height=891dp")
+@Preview(showSystemUi = true, device = "spec:width=673.5dp,height=841dp,dpi=480")
+@Preview(showSystemUi = true, device = "spec:width=1280dp,height=800dp,dpi=480")
+@Preview(showSystemUi = true, device = "spec:width=1920dp,height=1080dp,dpi=480")
+annotation class DevicePreviews

--- a/app/src/main/res/drawable/ic_map_location.xml
+++ b/app/src/main/res/drawable/ic_map_location.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+  <path
+      android:pathData="M100,100m-100,0a100,100 0,1 1,200 0a100,100 0,1 1,-200 0"
+      android:fillColor="#D9E5FD"/>
+  <group>
+    <clip-path
+        android:pathData="M59,79L142,79A8,8 0,0 1,150 87L150,135.5A8,8 0,0 1,142 143.5L59,143.5A8,8 0,0 1,51 135.5L51,87A8,8 0,0 1,59 79z"/>
+    <path
+        android:pathData="M59,79L142,79A8,8 0,0 1,150 87L150,135.5A8,8 0,0 1,142 143.5L59,143.5A8,8 0,0 1,51 135.5L51,87A8,8 0,0 1,59 79z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.75"/>
+    <path
+        android:pathData="M73,97.5L53.5,79H150.5V88L73,97.5Z"
+        android:fillColor="#A6C5FB"/>
+    <path
+        android:pathData="M62,97.5L51,88V100.5L62,97.5Z"
+        android:fillColor="#A6C5FB"/>
+    <path
+        android:pathData="M73,103L51,106V123.5L73,119L108.5,143.5H142L73,103Z"
+        android:fillColor="#A6C5FB"/>
+    <path
+        android:pathData="M73,128.5L51,132V143.5H90L73,128.5Z"
+        android:fillColor="#A6C5FB"/>
+    <path
+        android:pathData="M90,103L150.5,140V97.5L90,103Z"
+        android:fillColor="#A6C5FB"/>
+  </group>
+  <path
+      android:pathData="M74.63,109.31C74.63,109.32 74.65,109.34 74.65,109.34C74.65,109.34 92.63,81.99 92.63,73C92.63,59.77 83.52,54.02 74.63,54C65.74,54.02 56.63,59.77 56.63,73C56.63,81.99 74.62,109.34 74.62,109.34L74.63,109.31ZM68.4,72.25C68.4,68.83 71.19,66.07 74.64,66.07C78.09,66.07 80.88,68.83 80.88,72.25C80.88,75.67 78.08,78.43 74.63,78.43C71.19,78.43 68.4,75.67 68.4,72.25Z"
+      android:fillColor="#2279FD"/>
+  <path
+      android:pathData="M119.18,135.87C119.18,135.88 119.2,135.9 119.2,135.9C119.2,135.9 137.18,108.55 137.18,99.57C137.18,86.34 128.07,80.58 119.18,80.56C110.29,80.58 101.18,86.34 101.18,99.57C101.18,108.55 119.17,135.9 119.17,135.9L119.18,135.87ZM112.95,98.81C112.95,95.4 115.74,92.63 119.19,92.63C122.64,92.63 125.43,95.4 125.43,98.81C125.43,102.23 122.63,104.99 119.18,104.99C115.74,104.99 112.95,102.23 112.95,98.81Z"
+      android:fillColor="#2279FD"/>
+</vector>


### PR DESCRIPTION
This PR deals with the creation `Finalising Driver` screen with the `ProgressBar Animation`.

> Note: The ProgressBar animation does not survive configuration changes (or screen size changes) because the animation APIs like `animate*AsState` internally use `remember` instead of `rememberSaveable`.

Demo:
<img src="https://user-images.githubusercontent.com/89389061/191567908-3eefb589-0453-48fb-ae11-11a6a2c9c980.gif" width="500" />
